### PR TITLE
perf(sync): run initial cache sync check immediately

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -220,7 +220,7 @@ func (s *KubeFedSyncController) Run(stopChan <-chan struct{}) {
 
 // Wait until all data stores are in sync for a definitive timeout, and returns if there is an error or a timeout.
 func (s *KubeFedSyncController) waitForSync() error {
-	return wait.PollUntilContextTimeout(context.Background(), utils.SyncedPollPeriod, s.cacheSyncTimeout, false, func(ctx context.Context) (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), utils.SyncedPollPeriod, s.cacheSyncTimeout, true, func(ctx context.Context) (done bool, err error) {
 		return s.isSynced(), nil
 	})
 }
@@ -457,7 +457,7 @@ func (s *KubeFedSyncController) setFederatedStatus(fedResource FederatedResource
 
 	// If the underlying resource has changed, attempt to retrieve and
 	// update it repeatedly.
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Second, false, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if updateRequired, err := status.SetFederatedStatus(obj, reason, *collectedStatus, *collectedResourceStatus, resourceStatusCollection); err != nil {
 			klog.V(4).Infof("Failed to set the status for %s %q", kind, name)
 			return false, errors.Wrapf(err, "failed to set the status")

--- a/pkg/controller/sync/version/manager.go
+++ b/pkg/controller/sync/version/manager.go
@@ -291,7 +291,7 @@ func (m *Manager) writeVersion(obj runtimeclient.Object, qualifiedName utils.Qua
 	refreshVersion := false
 	// TODO(marun) Centralize polling interval and duration
 	waitDuration := 30 * time.Second
-	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, waitDuration, false, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, waitDuration, true, func(ctx context.Context) (done bool, err error) {
 		if refreshVersion {
 			// Version was written to the API by another process after the last manager write.
 			resourceVersion, err = m.getResourceVersionFromAPI(qualifiedName)

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -484,7 +484,7 @@ func CreateFederatedResource(hostConfig *rest.Config, typeConfig typeconfig.Inte
 	if !dryRun {
 		// It might take a little while for the federated type to appear if the
 		// same is being enabled while or immediately before federating the resource.
-		err = wait.PollUntilContextTimeout(context.Background(), createResourceRetryInterval, createResourceRetryTimeout, false, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), createResourceRetryInterval, createResourceRetryTimeout, true, func(ctx context.Context) (done bool, err error) {
 			_, err = fedClient.Resources(federatedResource.GetNamespace()).Create(context.Background(), federatedResource, metav1.CreateOptions{})
 			if apierrors.IsNotFound(err) {
 				return false, nil

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -317,7 +317,7 @@ func (c *FederatedTypeCrudTester) CheckDelete(ctx context.Context, immediate boo
 
 	// Wait for deletion.  The federated resource will only be removed once managed resources have
 	// been deleted or orphaned.
-	err = wait.PollUntilContextTimeout(ctx, c.waitInterval, waitTimeout, false, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, c.waitInterval, waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		_, err = resourceClient.Resources(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
@@ -530,7 +530,7 @@ func (c *FederatedTypeCrudTester) CheckPropagation(ctx context.Context, immediat
 		// Use a longer wait interval to avoid spamming the test log.
 		waitInterval := 1 * time.Second
 		var waitingForError error
-		err = wait.PollUntilContextTimeout(context.Background(), waitInterval, c.clusterWaitTimeout, false, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), waitInterval, c.clusterWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 			ok, err := c.checkFederatedStatus(fedObject, clusterName, objExpected)
 			if err != nil {
 				// Logging lots of waiting messages would clutter the
@@ -719,7 +719,7 @@ func (c *FederatedTypeCrudTester) waitForResourceDeletion(ctx context.Context, i
 func (c *FederatedTypeCrudTester) updateObject(ctx context.Context, apiResource metav1.APIResource, obj *unstructured.Unstructured, mutateResourceFunc func(*unstructured.Unstructured)) (*unstructured.Unstructured, error) {
 	resourceClient := c.resourceClient(apiResource)
 	var updatedObj *unstructured.Unstructured
-	err := wait.PollUntilContextTimeout(ctx, c.waitInterval, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, c.waitInterval, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		mutateResourceFunc(obj)
 
 		var err error

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -46,7 +46,7 @@ import (
 var _ = ginkgo.Describe("Federated CRD resources", func() {
 	f := framework.NewKubeFedFramework("crd-resources")
 	ctx := context.Background()
-	immediate := false
+	immediate := true
 	namespaceScoped := []bool{
 		true,
 		false,

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -47,7 +47,7 @@ type testObjectsAccessor func(namespace string, clusterNames []string) (targetOb
 var _ = Describe("Federated", func() {
 	f := framework.NewKubeFedFramework("federated-types")
 	ctx := context.Background()
-	immediate := false
+	immediate := true
 	tl := framework.NewE2ELogger()
 
 	typeConfigFixtures := common.TypeConfigFixturesOrDie(tl)

--- a/test/e2e/deleteoptions.go
+++ b/test/e2e/deleteoptions.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo" //nolint:stylecheck
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,7 +32,7 @@ var typeConfigName = "deployments.apps"
 var _ = Describe("DeleteOptions", func() {
 	f := framework.NewKubeFedFramework("delete-options")
 	ctx := context.Background()
-	immediate := false
+	immediate := true
 	tl := framework.NewE2ELogger()
 
 	typeConfigFixtures := common.TypeConfigFixturesOrDie(tl)

--- a/test/e2e/not_ready.go
+++ b/test/e2e/not_ready.go
@@ -60,7 +60,7 @@ var _ = Describe("[NOT_READY] Simulated not-ready nodes", func() {
 	baseName := "unhealthy-test"
 	f := framework.NewKubeFedFramework(baseName)
 	ctx := context.Background()
-	immediate := false
+	immediate := true
 	tl := framework.NewE2ELogger()
 
 	typeConfigFixtures := common.TypeConfigFixturesOrDie(tl)

--- a/test/e2e/placement.go
+++ b/test/e2e/placement.go
@@ -38,7 +38,7 @@ import (
 var _ = Describe("Placement", func() {
 	f := framework.NewKubeFedFramework("placement")
 	ctx := context.Background()
-	immediate := false
+	immediate := true
 	tl := framework.NewE2ELogger()
 
 	typeConfigFixtures := common.TypeConfigFixturesOrDie(tl)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -68,7 +68,7 @@ var _ = Describe("Simulated Scale", func() {
 	baseName := "scale-test"
 	f := framework.NewKubeFedFramework(baseName)
 	ctx := context.Background()
-	immediate := false
+	immediate := true
 	tl := framework.NewE2ELogger()
 
 	typeConfigFixtures := common.TypeConfigFixturesOrDie(tl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Set `immediate=true` in `wait.PollUntilContextTimeout`.This removes the initial SyncedPollPeriod delay and allows the controller to return faster if caches are already synced.
